### PR TITLE
Remove deprecated gemspec entry

### DIFF
--- a/simplecov-json.gemspec
+++ b/simplecov-json.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %Q{JSON formatter for SimpleCov code coverage tool for ruby 1.9+}
   s.description = %Q{JSON formatter for SimpleCov code coverage tool for ruby 1.9+}
 
-  s.rubyforge_project = "simplecov-json"
   s.files         = ['lib/simplecov-json.rb']
   s.test_files    = ['test/helper.rb', 'test/test_simplecov_json.rb']
   s.require_paths = ["lib"]


### PR DESCRIPTION
Fix this warning.

```
NOTE: Gem::Specification#rubyforge_project= is deprecated with no replacement. It will be removed on or after 2019-12-01.
Gem::Specification#rubyforge_project= called from /Users/jnito/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/bundler/gems/simplecov-json-1d54d90eeeca/simplecov-json.gemspec:15
```